### PR TITLE
Setup new variables needed for Datadog logging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -209,6 +209,16 @@ resource "kubernetes_daemonset" "datadog_agent" {
           }
 
           env {
+            name = "DD_LOGS_ENABLED"
+            value = var.datadog_agent_options_logs_enabled
+          }
+
+          env {
+            name = "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL"
+            value = var.datadog_agent_options_logs_enabled
+          }
+
+          env {
             name = "DD_KUBERNETES_KUBELET_HOST"
             value_from {
               field_ref {
@@ -223,12 +233,12 @@ resource "kubernetes_daemonset" "datadog_agent" {
           }
 
           resources {
-            requests {
+            requests = {
               memory = "256Mi"
               cpu = "200m"
             }
 
-            limits {
+            limits = {
               memory = "256Mi"
               cpu = "200m"
             }

--- a/resources/datadog-agent.yaml
+++ b/resources/datadog-agent.yaml
@@ -83,6 +83,7 @@ spec:
           - {name: cgroups, mountPath: /host/sys/fs/cgroup, readOnly: true}
           - {name: s6-run, mountPath: /var/run/s6}
           - {name: logpodpath, mountPath: /var/log/pods}
+          - {name: pointerdir, mountPath: /opt/datadog-agent/run}
           ## Docker runtime directory, replace this path with your container runtime
           ## logs directory, or remove this configuration if `/var/log/pods`
           ## is not a symlink to any other directory.
@@ -102,6 +103,7 @@ spec:
         - {name: cgroups, hostPath: {path: /sys/fs/cgroup}}
         - {name: s6-run, emptyDir: {}}
         - {name: logpodpath, hostPath: {path: /var/log/pods}}
+        - {name: pointerdir, hostPath: {path: /opt/datadog-agent/run}}
         ## Docker runtime directory, replace this path with your container runtime
         ## logs directory, or remove this configuration if `/var/log/pods`
         ## is not a symlink to any other directory.

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,12 @@ variable "datadog_agent_options_apm_enabled" {
   description = "Enable APM logging?"
 }
 
+variable "datadog_agent_options_logs_enabled" {
+  type = bool
+  default = true
+  description = "Enable datadog logs?"
+}
+
 variable "datadog_agent_options_collect_kubernetes_events" {
   type = bool
   default = true


### PR DESCRIPTION
The original repo for setting up the Datadog agent does not have everything we need for Datadog logging.

We have forked the original repo and trying and adding environment variables needed. Once merging this, will then link this repo on the Terraform registry and should be able to pull from there.